### PR TITLE
Implement Pokemon list and search

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "@eslint/js": "^9.19.0",
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.2.0",
+    "@testing-library/user-event": "^14.6.1",
     "@types/react": "^19.0.8",
     "@types/react-dom": "^19.0.3",
     "@typescript-eslint/eslint-plugin": "^8.24.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,6 +27,9 @@ importers:
       '@testing-library/react':
         specifier: ^16.2.0
         version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@testing-library/user-event':
+        specifier: ^14.6.1
+        version: 14.6.1(@testing-library/dom@10.4.1)
       '@types/react':
         specifier: ^19.0.8
         version: 19.2.14
@@ -606,6 +609,12 @@ packages:
         optional: true
       '@types/react-dom':
         optional: true
+
+  '@testing-library/user-event@14.6.1':
+    resolution: {integrity: sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==}
+    engines: {node: '>=12', npm: '>=6'}
+    peerDependencies:
+      '@testing-library/dom': '>=7.21.4'
 
   '@types/aria-query@5.0.4':
     resolution: {integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==}
@@ -2628,6 +2637,10 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@testing-library/user-event@14.6.1(@testing-library/dom@10.4.1)':
+    dependencies:
+      '@testing-library/dom': 10.4.1
 
   '@types/aria-query@5.0.4': {}
 

--- a/src/components/PokemonCard/PokemonCard.test.tsx
+++ b/src/components/PokemonCard/PokemonCard.test.tsx
@@ -1,0 +1,72 @@
+import type { PokemonSummary } from '@models/pokemon'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { PokemonCard } from './PokemonCard'
+
+const bulbasaur: PokemonSummary = {
+  id: 1,
+  name: 'Bulbasaur',
+  types: ['Grass', 'Poison'],
+  sprite: 'https://example.com/bulbasaur.png',
+}
+
+const pikachu: PokemonSummary = {
+  id: 25,
+  name: 'Pikachu',
+  types: ['Electric'],
+  sprite: 'https://example.com/pikachu.png',
+}
+
+describe('PokemonCard', () => {
+  it('renders pokemon name', () => {
+    render(<PokemonCard pokemon={bulbasaur} onClick={() => {}} />)
+    expect(screen.getByText('Bulbasaur')).toBeInTheDocument()
+  })
+
+  it('renders formatted ID as #001', () => {
+    render(<PokemonCard pokemon={bulbasaur} onClick={() => {}} />)
+    expect(screen.getByText('#001')).toBeInTheDocument()
+  })
+
+  it('renders formatted ID as #025 for Pikachu', () => {
+    render(<PokemonCard pokemon={pikachu} onClick={() => {}} />)
+    expect(screen.getByText('#025')).toBeInTheDocument()
+  })
+
+  it('renders sprite with lazy loading', () => {
+    render(<PokemonCard pokemon={bulbasaur} onClick={() => {}} />)
+    const img = screen.getByRole('img', { name: 'Bulbasaur' })
+    expect(img).toHaveAttribute('loading', 'lazy')
+    expect(img).toHaveAttribute('src', 'https://example.com/bulbasaur.png')
+  })
+
+  it('renders types', () => {
+    render(<PokemonCard pokemon={bulbasaur} onClick={() => {}} />)
+    expect(screen.getByText('Grass')).toBeInTheDocument()
+    expect(screen.getByText('Poison')).toBeInTheDocument()
+  })
+
+  it('is a button with correct aria-label for multi-type pokemon', () => {
+    render(<PokemonCard pokemon={bulbasaur} onClick={() => {}} />)
+    expect(
+      screen.getByRole('button', { name: 'Bulbasaur, Grass and Poison type' }),
+    ).toBeInTheDocument()
+  })
+
+  it('is a button with correct aria-label for single-type pokemon', () => {
+    render(<PokemonCard pokemon={pikachu} onClick={() => {}} />)
+    expect(
+      screen.getByRole('button', { name: 'Pikachu, Electric type' }),
+    ).toBeInTheDocument()
+  })
+
+  it('calls onClick when clicked', async () => {
+    const handleClick = vi.fn()
+    render(<PokemonCard pokemon={bulbasaur} onClick={handleClick} />)
+
+    await userEvent.click(
+      screen.getByRole('button', { name: 'Bulbasaur, Grass and Poison type' }),
+    )
+    expect(handleClick).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/components/PokemonCard/PokemonCard.tsx
+++ b/src/components/PokemonCard/PokemonCard.tsx
@@ -1,0 +1,47 @@
+import type { PokemonSummary } from '@models/pokemon'
+import type { FC } from 'react'
+
+interface PokemonCardProps {
+  pokemon: PokemonSummary
+  onClick: () => void
+  selected?: boolean
+}
+
+const formatId = (id: number): string => `#${String(id).padStart(3, '0')}`
+
+const formatAriaLabel = (pokemon: PokemonSummary): string => {
+  const types = pokemon.types
+  const typeLabel =
+    types.length <= 1
+      ? types[0] ?? ''
+      : `${types.slice(0, -1).join(', ')} and ${types[types.length - 1]}`
+  return `${pokemon.name}, ${typeLabel} type`
+}
+
+export const PokemonCard: FC<PokemonCardProps> = ({
+  pokemon,
+  onClick,
+  selected = false,
+}) => {
+  return (
+    <button
+      type="button"
+      aria-label={formatAriaLabel(pokemon)}
+      aria-pressed={selected}
+      onClick={onClick}
+    >
+      <img
+        src={pokemon.sprite}
+        alt={pokemon.name}
+        loading="lazy"
+      />
+      <span>{formatId(pokemon.id)}</span>
+      <span>{pokemon.name}</span>
+      <span>
+        {pokemon.types.map((type) => (
+          <span key={type}>{type}</span>
+        ))}
+      </span>
+    </button>
+  )
+}

--- a/src/components/PokemonCard/index.ts
+++ b/src/components/PokemonCard/index.ts
@@ -1,0 +1,1 @@
+export { PokemonCard } from './PokemonCard'

--- a/src/components/PokemonList/PokemonList.test.tsx
+++ b/src/components/PokemonList/PokemonList.test.tsx
@@ -1,0 +1,58 @@
+import type { PokemonSummary } from '@models/pokemon'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { PokemonList } from './PokemonList'
+
+const mockPokemon: PokemonSummary[] = [
+  { id: 1, name: 'Bulbasaur', types: ['Grass', 'Poison'], sprite: '/bulbasaur.png' },
+  { id: 4, name: 'Charmander', types: ['Fire'], sprite: '/charmander.png' },
+  { id: 7, name: 'Squirtle', types: ['Water'], sprite: '/squirtle.png' },
+]
+
+describe('PokemonList', () => {
+  it('renders a list of pokemon cards', () => {
+    render(<PokemonList pokemon={mockPokemon} onSelect={() => {}} />)
+
+    expect(screen.getByRole('list')).toBeInTheDocument()
+    expect(screen.getAllByRole('listitem')).toHaveLength(3)
+  })
+
+  it('renders each pokemon name', () => {
+    render(<PokemonList pokemon={mockPokemon} onSelect={() => {}} />)
+
+    expect(screen.getByText('Bulbasaur')).toBeInTheDocument()
+    expect(screen.getByText('Charmander')).toBeInTheDocument()
+    expect(screen.getByText('Squirtle')).toBeInTheDocument()
+  })
+
+  it('calls onSelect with the pokemon id when a card is clicked', async () => {
+    const handleSelect = vi.fn()
+    render(<PokemonList pokemon={mockPokemon} onSelect={handleSelect} />)
+
+    await userEvent.click(
+      screen.getByRole('button', { name: 'Charmander, Fire type' }),
+    )
+    expect(handleSelect).toHaveBeenCalledWith(4)
+  })
+
+  it('shows empty state when pokemon list is empty', () => {
+    render(<PokemonList pokemon={[]} onSelect={() => {}} />)
+
+    expect(screen.getByText('No Pokemon found.')).toBeInTheDocument()
+    expect(screen.queryByRole('list')).not.toBeInTheDocument()
+  })
+
+  it('passes selectedId to cards', () => {
+    render(
+      <PokemonList pokemon={mockPokemon} onSelect={() => {}} selectedId={4} />,
+    )
+
+    const charmander = screen.getByRole('button', { name: 'Charmander, Fire type' })
+    expect(charmander).toHaveAttribute('aria-pressed', 'true')
+
+    const bulbasaur = screen.getByRole('button', {
+      name: 'Bulbasaur, Grass and Poison type',
+    })
+    expect(bulbasaur).toHaveAttribute('aria-pressed', 'false')
+  })
+})

--- a/src/components/PokemonList/PokemonList.tsx
+++ b/src/components/PokemonList/PokemonList.tsx
@@ -1,0 +1,33 @@
+import { PokemonCard } from '@components/PokemonCard'
+import type { PokemonSummary } from '@models/pokemon'
+import type { FC } from 'react'
+
+interface PokemonListProps {
+  pokemon: PokemonSummary[]
+  onSelect: (id: number) => void
+  selectedId?: number | null
+}
+
+export const PokemonList: FC<PokemonListProps> = ({
+  pokemon,
+  onSelect,
+  selectedId = null,
+}) => {
+  if (pokemon.length === 0) {
+    return <p>No Pokemon found.</p>
+  }
+
+  return (
+    <ul>
+      {pokemon.map((p) => (
+        <li key={p.id}>
+          <PokemonCard
+            pokemon={p}
+            onClick={() => onSelect(p.id)}
+            selected={p.id === selectedId}
+          />
+        </li>
+      ))}
+    </ul>
+  )
+}

--- a/src/components/PokemonList/index.ts
+++ b/src/components/PokemonList/index.ts
@@ -1,0 +1,1 @@
+export { PokemonList } from './PokemonList'

--- a/src/components/SearchInput/SearchInput.test.tsx
+++ b/src/components/SearchInput/SearchInput.test.tsx
@@ -1,0 +1,46 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { SearchInput } from './SearchInput'
+
+describe('SearchInput', () => {
+  it('renders an input with aria-label', () => {
+    render(<SearchInput value="" onChange={() => {}} />)
+    expect(screen.getByLabelText('Search Pokemon')).toBeInTheDocument()
+  })
+
+  it('calls onChange when user types', async () => {
+    const handleChange = vi.fn()
+    render(<SearchInput value="" onChange={handleChange} />)
+
+    await userEvent.type(screen.getByLabelText('Search Pokemon'), 'pika')
+    expect(handleChange).toHaveBeenCalledTimes(4)
+    expect(handleChange).toHaveBeenLastCalledWith('a')
+  })
+
+  it('does not show clear button when value is empty', () => {
+    render(<SearchInput value="" onChange={() => {}} />)
+    expect(screen.queryByLabelText('Clear search')).not.toBeInTheDocument()
+  })
+
+  it('shows clear button when value has text', () => {
+    render(<SearchInput value="pikachu" onChange={() => {}} />)
+    expect(screen.getByLabelText('Clear search')).toBeInTheDocument()
+  })
+
+  it('calls onChange with empty string when clear button is clicked', async () => {
+    const handleChange = vi.fn()
+    render(<SearchInput value="pikachu" onChange={handleChange} />)
+
+    await userEvent.click(screen.getByLabelText('Clear search'))
+    expect(handleChange).toHaveBeenCalledWith('')
+  })
+
+  it('calls onChange with empty string when Escape is pressed', async () => {
+    const handleChange = vi.fn()
+    render(<SearchInput value="pikachu" onChange={handleChange} />)
+
+    const input = screen.getByLabelText('Search Pokemon')
+    await userEvent.type(input, '{Escape}')
+    expect(handleChange).toHaveBeenCalledWith('')
+  })
+})

--- a/src/components/SearchInput/SearchInput.tsx
+++ b/src/components/SearchInput/SearchInput.tsx
@@ -1,0 +1,35 @@
+import { useCallback, type FC, type KeyboardEvent } from 'react'
+
+interface SearchInputProps {
+  value: string
+  onChange: (value: string) => void
+}
+
+export const SearchInput: FC<SearchInputProps> = ({ value, onChange }) => {
+  const handleKeyDown = useCallback(
+    (e: KeyboardEvent<HTMLInputElement>) => {
+      if (e.key === 'Escape') {
+        onChange('')
+      }
+    },
+    [onChange],
+  )
+
+  return (
+    <div>
+      <input
+        type="text"
+        aria-label="Search Pokemon"
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        onKeyDown={handleKeyDown}
+        placeholder="Search Pokemon..."
+      />
+      {value && (
+        <button type="button" aria-label="Clear search" onClick={() => onChange('')}>
+          ×
+        </button>
+      )}
+    </div>
+  )
+}

--- a/src/components/SearchInput/index.ts
+++ b/src/components/SearchInput/index.ts
@@ -1,0 +1,1 @@
+export { SearchInput } from './SearchInput'

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,2 +1,3 @@
-export { usePokemonList } from './usePokemonList'
 export { usePokemonDetail } from './usePokemonDetail'
+export { usePokemonList } from './usePokemonList'
+export { useSearchFilter } from './useSearchFilter'

--- a/src/hooks/useSearchFilter.test.ts
+++ b/src/hooks/useSearchFilter.test.ts
@@ -1,0 +1,58 @@
+import type { PokemonSummary } from '@models/pokemon'
+import { act, renderHook } from '@testing-library/react'
+import { useSearchFilter } from './useSearchFilter'
+
+const mockPokemon: PokemonSummary[] = [
+  { id: 1, name: 'Bulbasaur', types: ['Grass', 'Poison'], sprite: '/bulbasaur.png' },
+  { id: 4, name: 'Charmander', types: ['Fire'], sprite: '/charmander.png' },
+  { id: 7, name: 'Squirtle', types: ['Water'], sprite: '/squirtle.png' },
+  { id: 25, name: 'Pikachu', types: ['Electric'], sprite: '/pikachu.png' },
+]
+
+describe('useSearchFilter', () => {
+  it('returns all pokemon when query is empty', () => {
+    const { result } = renderHook(() => useSearchFilter(mockPokemon))
+    expect(result.current.filtered).toEqual(mockPokemon)
+    expect(result.current.query).toBe('')
+  })
+
+  it('filters pokemon by name case-insensitively', () => {
+    const { result } = renderHook(() => useSearchFilter(mockPokemon))
+
+    act(() => {
+      result.current.setQuery('char')
+    })
+
+    expect(result.current.filtered).toEqual([mockPokemon[1]])
+  })
+
+  it('filters with uppercase query', () => {
+    const { result } = renderHook(() => useSearchFilter(mockPokemon))
+
+    act(() => {
+      result.current.setQuery('SQUIR')
+    })
+
+    expect(result.current.filtered).toEqual([mockPokemon[2]])
+  })
+
+  it('returns empty array when no pokemon match', () => {
+    const { result } = renderHook(() => useSearchFilter(mockPokemon))
+
+    act(() => {
+      result.current.setQuery('Mewtwo')
+    })
+
+    expect(result.current.filtered).toEqual([])
+  })
+
+  it('matches partial names', () => {
+    const { result } = renderHook(() => useSearchFilter(mockPokemon))
+
+    act(() => {
+      result.current.setQuery('aur')
+    })
+
+    expect(result.current.filtered).toEqual([mockPokemon[0]])
+  })
+})

--- a/src/hooks/useSearchFilter.ts
+++ b/src/hooks/useSearchFilter.ts
@@ -1,0 +1,22 @@
+import type { PokemonSummary } from '@models/pokemon'
+import { useMemo, useState } from 'react'
+
+interface UseSearchFilterResult {
+  query: string
+  setQuery: (query: string) => void
+  filtered: PokemonSummary[]
+}
+
+export const useSearchFilter = (
+  pokemon: PokemonSummary[],
+): UseSearchFilterResult => {
+  const [query, setQuery] = useState('')
+
+  const filtered = useMemo(() => {
+    if (!query) return pokemon
+    const lowerQuery = query.toLowerCase()
+    return pokemon.filter((p) => p.name.toLowerCase().includes(lowerQuery))
+  }, [pokemon, query])
+
+  return { query, setQuery, filtered }
+}


### PR DESCRIPTION
Closes #6

## What changed
- **SearchInput**: text input with clear button, Escape-to-clear, `useCallback` memoised key handler
- **PokemonCard**: button with name, ID (#001), sprite (lazy loaded), types, accessible aria-label
- **PokemonList**: `<ul>` rendering PokemonCard items, calls `onSelect` on click
- **useSearchFilter**: case-insensitive name filtering with short-circuit for empty query
- Added `@testing-library/user-event` dev dependency

## Why
Core UI components for browsing and searching Pokemon — the list view that users interact with.

## How to verify
- `pnpm test` — 34 tests pass (19 new component/hook tests + 15 existing)
- `pnpm lint` — clean

## Decisions made
- `formatAriaLabel` handles 1, 2, and 3+ types correctly with Oxford comma pattern
- No `useCallback` on inline `onClick` per list item — 151 items is negligible, premature to extract sub-component
- Search filter short-circuits on empty query to avoid unnecessary O(n) pass