### PR TITLE
Ensure accessibility compliance

### DIFF
--- a/src/components/PokemonCard/PokemonCard.test.tsx
+++ b/src/components/PokemonCard/PokemonCard.test.tsx
@@ -69,4 +69,18 @@ describe('PokemonCard', () => {
     )
     expect(handleClick).toHaveBeenCalledTimes(1)
   })
+
+  it('has aria-pressed="false" when not selected', () => {
+    render(<PokemonCard pokemon={bulbasaur} onClick={() => {}} />)
+    expect(
+      screen.getByRole('button', { name: 'Bulbasaur, Grass and Poison type' }),
+    ).toHaveAttribute('aria-pressed', 'false')
+  })
+
+  it('has aria-pressed="true" when selected', () => {
+    render(<PokemonCard pokemon={bulbasaur} onClick={() => {}} selected />)
+    expect(
+      screen.getByRole('button', { name: 'Bulbasaur, Grass and Poison type' }),
+    ).toHaveAttribute('aria-pressed', 'true')
+  })
 })

--- a/src/components/StatBar/StatBar.test.tsx
+++ b/src/components/StatBar/StatBar.test.tsx
@@ -31,4 +31,12 @@ describe('StatBar', () => {
     const bar = container.querySelector('[style]')
     expect(bar).toHaveStyle({ width: '100%' })
   })
+
+  it('has role="progressbar" with correct aria value attributes', () => {
+    render(<StatBar label="Attack" value={49} maxValue={255} />)
+    const progressbar = screen.getByRole('progressbar', { name: 'Attack: 49 out of 255' })
+    expect(progressbar).toHaveAttribute('aria-valuenow', '49')
+    expect(progressbar).toHaveAttribute('aria-valuemin', '0')
+    expect(progressbar).toHaveAttribute('aria-valuemax', '255')
+  })
 })

--- a/src/pages/Pokedex/Pokedex.test.tsx
+++ b/src/pages/Pokedex/Pokedex.test.tsx
@@ -276,6 +276,25 @@ describe('Pokedex page', () => {
       })
     })
 
+    it('overlay has aria-modal attribute', async () => {
+      const user = userEvent.setup()
+      render(<Pokedex />, { wrapper: createWrapper() })
+
+      await waitFor(() => {
+        expect(screen.getByText('Pikachu')).toBeInTheDocument()
+      })
+
+      await user.click(
+        screen.getByRole('button', { name: 'Pikachu, Electric type' }),
+      )
+
+      await waitFor(() => {
+        const dialog = screen.getByRole('dialog')
+        expect(dialog).toHaveAttribute('aria-modal', 'true')
+        expect(dialog).toHaveAttribute('aria-label', 'Pokemon details')
+      })
+    })
+
     it('closes overlay when Escape is pressed', async () => {
       const user = userEvent.setup()
       render(<Pokedex />, { wrapper: createWrapper() })


### PR DESCRIPTION
Closes #13

## What changed
Accessibility audit found all implementation already compliant. Added missing test coverage:
- StatBar: `role="progressbar"`, `aria-valuenow/min/max` attributes
- PokemonCard: `aria-pressed` in selected and unselected states
- Pokedex page: mobile overlay `aria-modal="true"` and `aria-label`

## Why
Verification issue — ensures all accessibility ACs are both implemented and tested.

## How to verify
- `pnpm test` — 83 tests pass (4 new a11y tests + existing)

## Decisions made
- No implementation changes needed — all a11y was built into components during #6, #8, #10
- Only test coverage gaps were filled