### PR TITLE
Configure Vite for subpath deployment

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -2,6 +2,7 @@ import react from '@vitejs/plugin-react'
 import { defineConfig } from 'vitest/config'
 
 export default defineConfig({
+  base: '/apps/pokedex/',
   plugins: [react()],
   server: {
     proxy: {


### PR DESCRIPTION
Closes #15

## What changed
Set `base: '/apps/pokedex/'` in vite.config.ts so asset URLs resolve correctly when deployed to `akli.dev/apps/pokedex/`.

## Why
Without the base path, asset URLs would resolve to the root (`/assets/...`) instead of the subpath (`/apps/pokedex/assets/...`), causing 404s in production.

## How to verify
- `pnpm build` — check `dist/index.html` for `/apps/pokedex/assets/` paths
- `pnpm test` — 83 tests pass