### PR TITLE
State styling (loading, error, empty search, no-selection)

### DIFF
--- a/src/components/ErrorBoundary/ErrorBoundary.module.css
+++ b/src/components/ErrorBoundary/ErrorBoundary.module.css
@@ -1,0 +1,32 @@
+.container {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 16px;
+  padding: 24px;
+  border: 2px solid var(--color-border);
+  border-radius: 4px;
+  background-color: var(--color-surface);
+  text-align: center;
+}
+
+.message {
+  font-family: var(--font-pixel);
+  font-size: 12px;
+  color: var(--color-text);
+  margin: 0;
+  line-height: 1.8;
+}
+
+.retryButton {
+  font-family: var(--font-pixel);
+  font-size: 12px;
+  padding: 10px 24px;
+  border: 2px solid var(--color-border);
+  border-radius: 4px;
+  background-color: var(--color-accent);
+  color: #fff;
+  cursor: pointer;
+  min-height: 44px;
+  min-width: 44px;
+}

--- a/src/components/ErrorBoundary/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary/ErrorBoundary.tsx
@@ -1,5 +1,5 @@
- 
 import { Component, type ErrorInfo, type ReactNode } from 'react'
+import styles from './ErrorBoundary.module.css'
 
 interface ErrorBoundaryProps {
   children: ReactNode
@@ -33,10 +33,11 @@ class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
   render(): ReactNode {
     if (this.state.error) {
       return (
-        <div role="alert">
-          <p>Something went wrong: {this.state.error.message}</p>
+        <div className={styles.container} role="alert">
+          <p className={styles.message}>Something went wrong: {this.state.error.message}</p>
           <button
             type="button"
+            className={styles.retryButton}
             onClick={() => this.setState({ error: null })}
           >
             Try again

--- a/src/components/PokemonDetail/PokemonDetail.module.css
+++ b/src/components/PokemonDetail/PokemonDetail.module.css
@@ -86,11 +86,41 @@
   gap: 8px;
 }
 
-.emptyText {
+@keyframes detailPulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.4; }
+}
+
+.loadingText {
+  font-family: var(--font-pixel);
+  font-size: 12px;
+  color: var(--color-text);
+  text-align: center;
+  padding: 32px 0;
+  animation: detailPulse 1.5s ease-in-out infinite;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .loadingText {
+    animation: none;
+  }
+}
+
+.errorText {
+  font-family: var(--font-pixel);
+  font-size: 12px;
+  color: var(--color-text);
+  text-align: center;
+  padding: 32px 0;
+}
+
+.noSelection {
   font-family: var(--font-pixel);
   font-size: 12px;
   color: var(--color-text-secondary);
   text-align: center;
+  padding: 32px 0;
+  opacity: 0.7;
 }
 
 @media (min-width: 768px) {

--- a/src/components/PokemonDetail/PokemonDetail.tsx
+++ b/src/components/PokemonDetail/PokemonDetail.tsx
@@ -25,11 +25,11 @@ export const PokemonDetail: FC<PokemonDetailProps> = ({
   error,
 }) => {
   const renderContent = () => {
-    if (loading) return <p className={styles.emptyText}>Loading...</p>
-    if (error) return <p className={styles.emptyText}>Error: {error}</p>
+    if (loading) return <p className={styles.loadingText}>Loading...</p>
+    if (error) return <p className={styles.errorText}>Error: {error}</p>
     if (!pokemon)
       return (
-        <p className={styles.emptyText}>Select a Pokemon to view details</p>
+        <p className={styles.noSelection}>Select a Pokemon to view details</p>
       )
 
     return (

--- a/src/pages/Pokedex/Pokedex.module.css
+++ b/src/pages/Pokedex/Pokedex.module.css
@@ -1,3 +1,63 @@
+@keyframes pulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.4; }
+}
+
+.stateContainer {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 100vh;
+  padding: 16px;
+}
+
+.loadingText {
+  font-family: var(--font-pixel);
+  font-size: 14px;
+  color: var(--color-text);
+  text-align: center;
+  animation: pulse 1.5s ease-in-out infinite;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .loadingText {
+    animation: none;
+  }
+}
+
+.errorBox {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 16px;
+  padding: 24px;
+  border: 2px solid var(--color-border);
+  border-radius: 4px;
+  background-color: var(--color-surface);
+  text-align: center;
+}
+
+.errorText {
+  font-family: var(--font-pixel);
+  font-size: 12px;
+  color: var(--color-text);
+  margin: 0;
+  line-height: 1.8;
+}
+
+.retryButton {
+  font-family: var(--font-pixel);
+  font-size: 12px;
+  padding: 10px 24px;
+  border: 2px solid var(--color-border);
+  border-radius: 4px;
+  background-color: var(--color-accent);
+  color: #fff;
+  cursor: pointer;
+  min-height: 44px;
+  min-width: 44px;
+}
+
 .layout {
   display: flex;
   flex-direction: column;

--- a/src/pages/Pokedex/Pokedex.tsx
+++ b/src/pages/Pokedex/Pokedex.tsx
@@ -103,16 +103,22 @@ export const Pokedex: FC = () => {
   }, [isDesktop])
 
   if (listLoading) {
-    return <p>Loading Pokemon...</p>
+    return (
+      <div className={styles.stateContainer}>
+        <p className={styles.loadingText}>Loading Pokemon...</p>
+      </div>
+    )
   }
 
   if (listError) {
     return (
-      <div>
-        <p>Error: {listError}</p>
-        <button type="button" onClick={retry}>
-          Retry
-        </button>
+      <div className={styles.stateContainer}>
+        <div className={styles.errorBox}>
+          <p className={styles.errorText}>Error: {listError}</p>
+          <button type="button" className={styles.retryButton} onClick={retry}>
+            Retry
+          </button>
+        </div>
       </div>
     )
   }


### PR DESCRIPTION
Closes #5

## What changed
- **Loading state**: pulsing pixel font text with `prefers-reduced-motion` support
- **Error state**: retro-styled chunky bordered box with accent retry button (both Pokedex page and ErrorBoundary)
- **Empty search**: "No Pokemon found" in pixel font, centred, secondary colour
- **No-selection**: muted "Select a Pokemon" prompt in detail panel

## Why
All UI states need to match the retro Game Boy Color aesthetic for a consistent experience.

## How to verify
- `pnpm dev` — trigger each state (slow network for loading, bad URL for error, search gibberish for empty)
- `pnpm test` — 88 tests pass