### PR TITLE
Fix stat bar animation flash and highlight selected Pokemon

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pokedex",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src/components/PokemonCard/PokemonCard.module.css
+++ b/src/components/PokemonCard/PokemonCard.module.css
@@ -56,6 +56,7 @@
 
 .selected {
   border-color: var(--color-accent);
+  background-color: color-mix(in srgb, var(--color-accent) 12%, var(--color-surface));
 }
 
 .sprite {

--- a/src/components/PokemonDetail/PokemonDetail.tsx
+++ b/src/components/PokemonDetail/PokemonDetail.tsx
@@ -81,7 +81,7 @@ export const PokemonDetail: FC<PokemonDetailProps> = ({
             <dd className={styles.infoValue}>{pokemon.genderRate}</dd>
           </div>
         </dl>
-        <div className={styles.stats}>
+        <div key={pokemon.id} className={styles.stats}>
           {Object.entries(pokemon.stats).map(([key, value], index) => (
             <StatBar
               key={key}

--- a/src/components/PokemonList/PokemonList.tsx
+++ b/src/components/PokemonList/PokemonList.tsx
@@ -1,6 +1,6 @@
 import { PokemonCard } from '@components/PokemonCard'
 import type { PokemonSummary } from '@models/pokemon'
-import type { FC } from 'react'
+import { useEffect, useRef, type FC } from 'react'
 import styles from './PokemonList.module.css'
 
 interface PokemonListProps {
@@ -14,6 +14,14 @@ export const PokemonList: FC<PokemonListProps> = ({
   onSelect,
   selectedId = null,
 }) => {
+  const selectedRef = useRef<HTMLLIElement | null>(null)
+
+  useEffect(() => {
+    if (selectedId !== null && selectedRef.current) {
+      selectedRef.current.scrollIntoView?.({ block: 'nearest', behavior: 'smooth' })
+    }
+  }, [selectedId])
+
   if (pokemon.length === 0) {
     return <p className={styles.emptyState}>No Pokemon found.</p>
   }
@@ -21,7 +29,7 @@ export const PokemonList: FC<PokemonListProps> = ({
   return (
     <ul className={styles.list}>
       {pokemon.map((p) => (
-        <li key={p.id}>
+        <li key={p.id} ref={p.id === selectedId ? selectedRef : undefined}>
           <PokemonCard
             pokemon={p}
             onClick={() => onSelect(p.id)}

--- a/src/components/PokemonList/PokemonList.tsx
+++ b/src/components/PokemonList/PokemonList.tsx
@@ -1,6 +1,6 @@
 import { PokemonCard } from '@components/PokemonCard'
 import type { PokemonSummary } from '@models/pokemon'
-import { useEffect, useRef, type FC } from 'react'
+import type { FC } from 'react'
 import styles from './PokemonList.module.css'
 
 interface PokemonListProps {
@@ -14,14 +14,6 @@ export const PokemonList: FC<PokemonListProps> = ({
   onSelect,
   selectedId = null,
 }) => {
-  const selectedRef = useRef<HTMLLIElement | null>(null)
-
-  useEffect(() => {
-    if (selectedId !== null && selectedRef.current) {
-      selectedRef.current.scrollIntoView?.({ block: 'nearest', behavior: 'smooth' })
-    }
-  }, [selectedId])
-
   if (pokemon.length === 0) {
     return <p className={styles.emptyState}>No Pokemon found.</p>
   }
@@ -29,7 +21,7 @@ export const PokemonList: FC<PokemonListProps> = ({
   return (
     <ul className={styles.list}>
       {pokemon.map((p) => (
-        <li key={p.id} ref={p.id === selectedId ? selectedRef : undefined}>
+        <li key={p.id}>
           <PokemonCard
             pokemon={p}
             onClick={() => onSelect(p.id)}

--- a/src/components/StatBar/StatBar.module.css
+++ b/src/components/StatBar/StatBar.module.css
@@ -32,7 +32,7 @@
 .fill {
   height: 100%;
   border-radius: 2px;
-  width: var(--stat-width);
+  width: 0%;
   animation: fillBar 300ms ease-out forwards;
   animation-delay: calc(var(--stat-index, 0) * 75ms);
   transform-origin: left;
@@ -50,7 +50,7 @@
 @media (prefers-reduced-motion: reduce) {
   .fill {
     animation: none;
-    animation-delay: 0s;
+    width: var(--stat-width);
   }
 }
 


### PR DESCRIPTION
## Summary
- **Stat bar animation:** Set initial width to 0% so bars don't flash at full width before the animation starts. Added `key={pokemon.id}` on the stats container to retrigger animations when switching between cached Pokemon.
- **Selected card highlight:** Added accent-tinted background on selected Pokemon card so the selection is visually obvious in the list.

## How to verify
- Select a Pokemon — card should have accent border + tinted background
- Stat bars should animate from 0 to their value with staggered delay
- Switch to a previously viewed Pokemon — animation should replay
- No flash of full-width bars before animation starts

## Test plan
- [x] All 88 tests pass (`pnpm test`)