### PR TITLE
Migrate deploy workflow to OIDC and dedicated bucket

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  id-token: write
+  contents: read
+
 jobs:
   deploy:
     runs-on: ubuntu-latest
@@ -39,13 +43,12 @@ jobs:
         if: github.ref == 'refs/heads/main'
         uses: aws-actions/configure-aws-credentials@v5
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          role-to-assume: arn:aws:iam::713881813802:role/pokedex-deploy
           aws-region: eu-west-2
 
       - name: Deploy to S3
         if: github.ref == 'refs/heads/main'
-        run: aws s3 sync ./dist s3://${{ secrets.AWS_S3_BUCKET_NAME }}/apps/pokedex --delete
+        run: aws s3 sync ./dist s3://${{ vars.AWS_S3_BUCKET_NAME }}/apps/pokedex --delete
 
       - name: Invalidate CloudFront
         if: github.ref == 'refs/heads/main'


### PR DESCRIPTION
Closes #36

## What changed
Migrates `.github/workflows/deploy.yml` off the static AWS access key and shared bucket, onto OIDC role-assumption and the new dedicated `PokedexBucket`.

- **Credentials**: `role-to-assume: arn:aws:iam::713881813802:role/pokedex-deploy` (the per-app IAM role from `akli-infrastructure` #191), replacing `aws-access-key-id`/`aws-secret-access-key`.
- **Permissions**: added `id-token: write` (required to receive the OIDC token) and `contents: read` (declaring any `permissions:` key zeroes out unlisted scopes by default).
- **Deploy target**: `s3://${{ vars.AWS_S3_BUCKET_NAME }}/apps/pokedex` (the dedicated `PokedexBucket` from `akli-infrastructure` #192), keeping the `apps/pokedex` key prefix — CloudFront forwards the full request path as the object key without stripping it.
- Existing `if: github.ref == 'refs/heads/main'` guards on all three AWS steps were already correct here (unlike `sand-box`, which had a real bug) — left untouched.

`CLOUDFRONT_ID` secret and the `/apps/pokedex/*` invalidation path are untouched. `Lint`/`Test`/`Build` steps untouched.

## Why
Part of the **OIDC Deploy Credentials & Dedicated Bucket** milestone (PRD: `docs/prds/oidc-deploy-credentials.md`), mirroring the same migration already completed in `sand-box` and in progress for `personal-website`.

## Action required before merging to main
This repo currently has **zero** GitHub Actions repo Variables configured (`gh variable list` confirmed empty) — a repo **Variable** (not Secret) named `AWS_S3_BUCKET_NAME` must be created with value `akliinfrastructurestack-pokedexbuckete987f38f-ma87rpuh86j4` via **Settings → Secrets and variables → Actions → Variables tab**, or the first real deploy will sync to a malformed `s3:///apps/pokedex` path.

## How to verify
- Diff is confined to `.github/workflows/deploy.yml` (6 insertions, 3 deletions) — no application code touched.
- `pnpm lint` — clean.
- `pnpm test` — 88/88 passing (13 test files).
- `pnpm exec tsc --noEmit` — **fails**, but with a pre-existing error unrelated to this diff (`Cannot find module '@hooks'` in `src/pages/Pokedex/Pokedex.tsx`/`.test.tsx`), confirmed present on `main` via baseline check before this branch existed. Not introduced by this change, out of scope for this PR.
- **Cannot be fully verified without a real GitHub Actions run** — OIDC auth success, actual S3 write, and actual CloudFront invalidation all depend on the live trust policy and the repo Variable above being set. That's issue #37.

## Decisions made
- **Bucket name is a repo Variable, not a Secret**, deviating from the PRD's literal "update the secret" wording. Bucket names aren't sensitive, so a Secret is the wrong primitive (hides a non-sensitive value from PR review, secret values can't be viewed later without rotating). Matches the identical decision already made and shipped in the sibling `sand-box` repo for the same PRD pattern.
- **Role ARN stays hardcoded**, not a variable — matches the PRD's explicit position that role ARNs "are not sensitive... can be committed directly," and there's no meaningful benefit to indirection here.
- **Pre-existing `@hooks` typecheck error left alone** — confirmed present on `main` before this branch, unrelated to this diff's scope (workflow YAML only, no TypeScript files touched). Worth a separate look, not blocking this PR.

## Out of scope
No follow-up issues filed — `/simplify` found nothing actionable (all four review angles: reuse, simplification, efficiency, altitude came back clean, consistent with the already-validated `sand-box` pattern).