### PR TITLE
Move CLOUDFRONT_ID from Secret to repo Variable

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -52,4 +52,4 @@ jobs:
 
       - name: Invalidate CloudFront
         if: github.ref == 'refs/heads/main'
-        run: aws cloudfront create-invalidation --distribution-id ${{ secrets.CLOUDFRONT_ID }} --paths "/apps/pokedex/*"
+        run: aws cloudfront create-invalidation --distribution-id ${{ vars.CLOUDFRONT_ID }} --paths "/apps/pokedex/*"


### PR DESCRIPTION
Closes #41

## What changed
`.github/workflows/deploy.yml`'s `Invalidate CloudFront` step now reads `${{ vars.CLOUDFRONT_ID }}` instead of `${{ secrets.CLOUDFRONT_ID }}`.

## Why
A CloudFront distribution ID isn't sensitive — same reasoning already applied to `AWS_S3_BUCKET_NAME` in #36 and in `sand-box`. Secrets are the wrong primitive for non-sensitive, human-readable config.

## How to verify
- Single-line diff, YAML validated, `pnpm lint`/`pnpm test` unaffected (88/88 passing).
- Repo Variable `CLOUDFRONT_ID` = `E26U1RZQEHCH13` already created and confirmed present.

## Decisions made
Given this mirrors an already-reviewed pattern (bucket-name Secret→Variable conversion, validated three times now across this repo and `sand-box`), I ran a lightweight review instead of the full `/simplify` battery — proportional to a one-line change.

## Out of scope
None — this issue is standalone.