### PR TITLE
OIDC deploy migration: role-based auth, dedicated bucket, resource-ID variables

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -52,4 +52,4 @@ jobs:
 
       - name: Invalidate CloudFront
         if: github.ref == 'refs/heads/main'
-        run: aws cloudfront create-invalidation --distribution-id ${{ secrets.CLOUDFRONT_ID }} --paths "/apps/pokedex/*"
+        run: aws cloudfront create-invalidation --distribution-id ${{ vars.CLOUDFRONT_ID }} --paths "/apps/pokedex/*"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  id-token: write
+  contents: read
+
 jobs:
   deploy:
     runs-on: ubuntu-latest
@@ -39,13 +43,12 @@ jobs:
         if: github.ref == 'refs/heads/main'
         uses: aws-actions/configure-aws-credentials@v5
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          role-to-assume: arn:aws:iam::713881813802:role/pokedex-deploy
           aws-region: eu-west-2
 
       - name: Deploy to S3
         if: github.ref == 'refs/heads/main'
-        run: aws s3 sync ./dist s3://${{ secrets.AWS_S3_BUCKET_NAME }}/apps/pokedex --delete
+        run: aws s3 sync ./dist s3://${{ vars.AWS_S3_BUCKET_NAME }}/apps/pokedex --delete
 
       - name: Invalidate CloudFront
         if: github.ref == 'refs/heads/main'

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pokedex",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## What changed

Merges the **OIDC Deploy Credentials & Dedicated Bucket** milestone into `main` (PRD: `docs/prds/oidc-deploy-credentials.md`). Merging this PR triggers a real `push`-to-`main` deploy run via `.github/workflows/deploy.yml` — this is the live verification issue #37 needs.

- **#36** — migrated `deploy.yml` from static AWS keys to OIDC (`role-to-assume` against `arn:aws:iam::713881813802:role/pokedex-deploy`), retargeted the S3 sync to the new dedicated `PokedexBucket` via a repo Variable (`vars.AWS_S3_BUCKET_NAME`).
- **#41** — moved `CLOUDFRONT_ID` from a Secret to a repo Variable (`vars.CLOUDFRONT_ID`) — distribution IDs aren't sensitive, same reasoning as the bucket name.

Also bumps `package.json` to `1.2.2` (patch — both merged issues are `type:refactor`, no new behavior).

## Pre-merge state
- `AWS_S3_BUCKET_NAME` Variable = `akliinfrastructurestack-pokedexbuckete987f38f-ma87rpuh86j4` — already created and confirmed.
- `CLOUDFRONT_ID` Variable = `E26U1RZQEHCH13` — already created and confirmed.

## After merge — issue #37 verification steps
- Confirm the real `push`-to-`main` deploy run succeeds (build, OIDC auth, S3 sync, CloudFront invalidation) via actual CI logs, not just "the run went green."
- Once confirmed, remove the now-unused `AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY` secrets, and the now-fully-unused `AWS_S3_BUCKET_NAME`/`CLOUDFRONT_ID` *Secrets* (distinct from the new *Variables* of the same names).
- `https://akli.dev/apps/pokedex` serving correctly from the new origin is **still blocked** on `akli-infrastructure` #193 (CloudFront behavior repoint) — no visible change to the live site from this merge alone.