### PR TITLE
Fix @hooks barrel import failing tsc module resolution

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pokedex",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "private": true,
   "type": "module",
   "scripts": {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,6 +13,7 @@
     "paths": {
       "@api/*": ["src/api/*"],
       "@components/*": ["src/components/*"],
+      "@hooks": ["src/hooks/index.ts"],
       "@hooks/*": ["src/hooks/*"],
       "@pages/*": ["src/pages/*"],
       "@models/*": ["src/types/*"],


### PR DESCRIPTION
Closes #40

## What changed
Adds a bare `"@hooks": ["src/hooks/index.ts"]` entry to `tsconfig.json`'s `paths`, alongside the existing `"@hooks/*"` wildcard. Also bumps `package.json` to `1.2.3`.

## Why
`vite.config.ts` has a bare alias (`'@hooks': '/src/hooks'`) that resolves against `src/hooks/index.ts` at runtime — this is why `pnpm build`/`pnpm test` always passed despite the bare `import { ... } from '@hooks'` in `Pokedex.tsx` (and the `vi.mock('@hooks', ...)` in its test). But `tsconfig.json` only had the wildcard `"@hooks/*"`, which doesn't match a specifier with no subpath, so `tsc --noEmit` alone failed with TS2307. This closes the gap between Vite's and TypeScript's resolution behavior.

## How to verify
- `pnpm exec tsc --noEmit` — now zero errors (previously two TS2307 errors).
- `pnpm test` — 88/88 passing, unaffected.
- `pnpm lint` — clean.
- Diff is exactly `tsconfig.json` (+1 line) + the version bump — no application code touched.

## Decisions made
Kept the existing `"@hooks/*"` wildcard entry — both coexist, since the wildcard still covers any future subpath imports even though none currently exist.

## Out of scope
No follow-ups filed — this closes #40's stated scope in full. This was the last open `pokedex` issue outside the OIDC milestone.