### PR TITLE
Rename CLOUDFRONT_ID variable to AWS_CLOUDFRONT_DISTRIBUTION_ID

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -52,4 +52,4 @@ jobs:
 
       - name: Invalidate CloudFront
         if: github.ref == 'refs/heads/main'
-        run: aws cloudfront create-invalidation --distribution-id ${{ vars.CLOUDFRONT_ID }} --paths "/apps/pokedex/*"
+        run: aws cloudfront create-invalidation --distribution-id ${{ vars.AWS_CLOUDFRONT_DISTRIBUTION_ID }} --paths "/apps/pokedex/*"


### PR DESCRIPTION
Closes #44

## What changed
`.github/workflows/deploy.yml`'s `Invalidate CloudFront` step now reads `${{ vars.AWS_CLOUDFRONT_DISTRIBUTION_ID }}` instead of `${{ vars.CLOUDFRONT_ID }}`.

## Why
Naming consistency with `AWS_S3_BUCKET_NAME` and the same rename already applied in `sand-box`/`personal-website` — the `AWS_<SERVICE>_<RESOURCE>` pattern is now consistent across all four repos.

## How to verify
- Single-line diff, YAML validated, `pnpm test`/`pnpm lint`/`pnpm exec tsc --noEmit` all clean (88/88 passing).
- New repo Variable `AWS_CLOUDFRONT_DISTRIBUTION_ID` = `E26U1RZQEHCH13` already created and confirmed present.

## Out of scope
Removing the old `CLOUDFRONT_ID` Variable — that's a post-merge live-verification step, once a real deploy run confirms the new one works.