### PR TITLE
Rename CLOUDFRONT_ID to AWS_CLOUDFRONT_DISTRIBUTION_ID (naming consistency)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -52,4 +52,4 @@ jobs:
 
       - name: Invalidate CloudFront
         if: github.ref == 'refs/heads/main'
-        run: aws cloudfront create-invalidation --distribution-id ${{ vars.CLOUDFRONT_ID }} --paths "/apps/pokedex/*"
+        run: aws cloudfront create-invalidation --distribution-id ${{ vars.AWS_CLOUDFRONT_DISTRIBUTION_ID }} --paths "/apps/pokedex/*"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pokedex",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## What changed

Merges #44 into `main` — renames the `CLOUDFRONT_ID` repo Variable reference to `AWS_CLOUDFRONT_DISTRIBUTION_ID` in `.github/workflows/deploy.yml`, matching the naming convention already shipped in `sand-box`/`personal-website`. Pure rename, zero behavior change. Bumps `package.json` to `1.2.4`.

## Pre-merge state
New repo Variable `AWS_CLOUDFRONT_DISTRIBUTION_ID` = `E26U1RZQEHCH13` already created and confirmed present. Old `CLOUDFRONT_ID` Variable still exists (not yet removed) so the deploy has no gap.

## After merge
- Confirm the real deploy run succeeds via CI logs, using the renamed variable.
- Once confirmed, remove the old `CLOUDFRONT_ID` Variable.
- This closes out the last open item in `pokedex` for this milestone.