### PR TITLE
Change vite.config.ts base to subdomain root

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -2,7 +2,6 @@ import react from '@vitejs/plugin-react'
 import { defineConfig } from 'vitest/config'
 
 export default defineConfig({
-  base: '/apps/pokedex/',
   plugins: [react()],
   server: {
     proxy: {


### PR DESCRIPTION
Closes #48

## What changed
Removed the `base: '/apps/pokedex/'` option from `vite.config.ts`. Vite now defaults to `base: '/'`, so assets and routes resolve from the subdomain root.

## Why
Part of the Subdomain Migration milestone (`docs/prds/subdomain-migration.md`) — Pokedex is moving from `akli.dev/apps/pokedex` to its own dedicated subdomain, `pokedex.akli.dev`.

## How to verify
- `vite.config.ts` no longer sets `base` (defaults to `/`)
- `pnpm test`, `pnpm lint`, `pnpm exec tsc --noEmit` all pass

## Decisions made
- Removed the `base` key entirely rather than setting it to `'/'` explicitly, since `/` is Vite's default and there was no other reason for the key to exist.
- **Sequencing note surfaced during `/simplify` review**: this change is coupled to #49 (deploy workflow S3 target / CloudFront path) — `deploy.yml`'s deploy steps are gated on `github.ref == 'refs/heads/main'`, so merging this PR into `epic/subdomain-migration` is safe on its own, but the epic must not merge into `main` until #49 has also landed in the epic branch. Otherwise the live app would build with root-absolute asset paths while still syncing to the old `apps/pokedex` S3 prefix, breaking `akli.dev/apps/pokedex` on merge. This matches the milestone's existing sequencing (#48/#49 before #51's verify step) — flagging it here for visibility, no action needed in this PR.

## Out of scope
Deploy workflow changes (#49), manifest/favicon (#50), and live-deploy verification (#51) are separate issues in this milestone.