### PR TITLE
Update deploy workflow for bucket-root sync and new distribution

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -48,8 +48,8 @@ jobs:
 
       - name: Deploy to S3
         if: github.ref == 'refs/heads/main'
-        run: aws s3 sync ./dist s3://${{ vars.AWS_S3_BUCKET_NAME }}/apps/pokedex --delete
+        run: aws s3 sync ./dist s3://${{ vars.AWS_S3_BUCKET_NAME }} --delete --exclude "apps/pokedex/*"
 
       - name: Invalidate CloudFront
         if: github.ref == 'refs/heads/main'
-        run: aws cloudfront create-invalidation --distribution-id ${{ vars.AWS_CLOUDFRONT_DISTRIBUTION_ID }} --paths "/apps/pokedex/*"
+        run: aws cloudfront create-invalidation --distribution-id ${{ vars.AWS_CLOUDFRONT_DISTRIBUTION_ID }} --paths "/*"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -48,6 +48,8 @@ jobs:
 
       - name: Deploy to S3
         if: github.ref == 'refs/heads/main'
+        # TODO(subdomain-migration step 6): drop this exclude once the old
+        # apps/pokedex prefix is removed from the shared distribution's bucket.
         run: aws s3 sync ./dist s3://${{ vars.AWS_S3_BUCKET_NAME }} --delete --exclude "apps/pokedex/*"
 
       - name: Invalidate CloudFront


### PR DESCRIPTION
Closes #49

## What changed
- `Deploy to S3` step now syncs to `PokedexBucket`'s root (`s3://${{ vars.AWS_S3_BUCKET_NAME }}`) instead of the `apps/pokedex` prefix, with `--exclude "apps/pokedex/*"` added to protect the still-live old prefix from `--delete` during the transition.
- `Invalidate CloudFront` step's path changed from `/apps/pokedex/*` to `/*`.
- Variable *names* (`AWS_S3_BUCKET_NAME`, `AWS_CLOUDFRONT_DISTRIBUTION_ID`) are unchanged — only their runtime values get updated later, manually, once the dedicated `PokedexSiteStack` distribution exists.

## Why
Part of the Subdomain Migration milestone (`docs/prds/subdomain-migration.md`) — once #48 changed the build to resolve assets from root, the deploy pipeline needs to publish to a bucket root and invalidate the whole (dedicated) distribution to match.

## How to verify
- `.github/workflows/deploy.yml` diff matches both acceptance criteria in #49
- Branch guards (`if: github.ref == 'refs/heads/main'`) unchanged on both steps
- `pnpm test`, `pnpm lint` pass
- Confirmed via `akli-infrastructure`'s CDK (`lib/akli-infrastructure-stack.ts:52`) that `PokedexBucket` is a dedicated bucket, not shared with other apps — so this sync/invalidation only ever touches Pokedex's own content
- Cannot be fully verified without a real deploy run against the live `PokedexSiteStack` distribution (blocked on `akli-infrastructure`'s Deploy A landing first, per the PRD's sequencing)

## Decisions made
- Left `AWS_S3_BUCKET_NAME`/`AWS_CLOUDFRONT_DISTRIBUTION_ID` variable names untouched per the PRD's explicit note — only values change, later, manually.
- Added an inline TODO comment above the `Deploy to S3` step (`/simplify` finding) marking the `--exclude` flag as transitional, so it doesn't read as permanent config once the primary PRD's step 6 cleanup removes the old prefix.

## Out of scope
- `/simplify`'s efficiency finding (full-bucket `--delete` sync now requires listing the whole keyspace vs. the old prefix-scoped sync) is inherent to this issue's acceptance criteria and already tracked for resolution at the primary PRD's step 6, when the `--exclude` and the bucket-root-vs-prefix distinction both go away — no new follow-up filed.
- Manifest/favicon (#50) and live-deploy verification (#51) are separate issues in this milestone.